### PR TITLE
Bind translate, default options

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,14 +17,16 @@ const MISSING = typeof Symbol === 'function' ? Symbol() : '_missing';
  * @class I18n
  * @classdesc an object capable of translating keys and interpolate using given data object
  * @param {Object}   options.translations JSON compliant object
- * @param {String}   options.$scope       Root string to be use for looking for translation keys
- * @param {Function} options.missing      Method to call when key is not found
+ * @param {String}   [options.$scope]     Root string to be use for looking for translation keys
+ * @param {Function} [options.missing]    Method to call when key is not found
  */
 module.exports = class I18n {
-    constructor({translations, $scope, missing}) {
+    constructor({translations, $scope, missing} = {translations: {}, $scope: undefined, missing: undefined}) {
         this[TRANSLATIONS] = freeze(jsonclone(translations));
         this[MISSING] = missing || (() => {});
         this.$scope = $scope;
+
+        this.translate = this.translate.bind(this);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.0.0",
+  "version": "1.1.0-rc",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,6 +12,10 @@ describe('I18n', () => {
         assert(i18n.$scope === $scope);
     });
 
+    it('can initiate w/o options', () => {
+        expect(() => new I18n()).to.not.throw();
+    });
+
     it('instance translations cannot be set', () => {
         const newTranslations = {a: 1};
         i18n.translations = newTranslations;
@@ -50,6 +54,12 @@ describe('I18n', () => {
 
     it('i18n translates keys', () => {
         expect(i18n.translate('root.user.name')).to.equal('Martin');
+    });
+
+    it('translate function is bound to instance', () => {
+        const translate = i18n.translate;
+
+        expect(translate('root.user.name')).to.equal('Martin');
     });
 
     it('interpolates values', () => {


### PR DESCRIPTION
Binding the "translate" function allows for simpler shortcutting:

## Consumer code
### Before
```javascript
const i18n = new I18n({...});
const t = i18n.translate.bind(i18n);
```
### After
```javascript
const i18n = new I18n({...});
const t = i18n.translate;
// OR
const t = new I18n({...}).translate;
```