### PR TITLE
Lock singleton to global, add onmiss entry point

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.3.0",
+  "version": "1.4.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.3.0",
+  "version": "1.4.0-rc.1",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,9 @@ Make sure you only have one instance of I18n in your global scope
 ```javascript
 const i18n = I18n.singleton;
 
-i18n.$scope = 'my.scope'; // Optional
+// Optional:
+i18n.$scope = 'my.scope';
+i18n.onmiss((key, scope) => console.error(`Missing key "${key}" ${scope ? `In scope: "${scope}"`}`));
 i18n.add({...});
 ```
 Shortcut:

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -16,4 +16,17 @@ describe('missing keys report', () => {
 
         i18n.translate('a.missing.key');
     });
+
+    it('reports missing keys using "onmiss"', () => {
+        const i18n = new I18n({$scope: 'some.scope'});
+
+        i18n.onmiss((key, scope, translations) => {
+            expect(scope).to.equal('some.scope');
+            expect(key).to.equal('a.missing.key');
+            expect(translations).to.be.an('object');
+            expect(translations).to.be.empty;
+        });
+
+        i18n.translate('a.missing.key');
+    });
 });

--- a/tests/singleton.js
+++ b/tests/singleton.js
@@ -1,6 +1,6 @@
 const {expect} = require('chai');
 const importFresh = require('import-fresh');
-
+const _global = require('@fiverr/futile/lib/global');
 
 describe('Singleton', () => {
     it('sanity on importFresh', () => {
@@ -24,5 +24,28 @@ describe('Singleton', () => {
 
         expect(i18n_b.t('a')).to.equal('one');
         expect(i18n_b.t('b')).to.equal('three');
+    });
+
+    describe('singleton is locked to the global scope', () => {
+        const i18nInstance = importFresh('../').singleton;
+
+        it('Gets the global name "i18n"', () => {
+            expect(i18nInstance).to.equal(_global.i18n);
+        });
+
+        it('Can not be re assigned', () => {
+            _global.i18n = null;
+            expect(_global.i18n).to.equal(i18nInstance);
+            expect(_global.i18n).to.not.equal(null);
+        });
+
+        it('Can not ne deleted', () => {
+            delete _global.i18n;
+            expect(_global.i18n).to.be.an('object');
+        });
+
+        it('Is not enumerable on the global object', () => {
+            expect(_global).to.not.have.any.keys('i18n');
+        });
     });
 });


### PR DESCRIPTION
1. Lock the singleton to the global object, so it can not be removed or run over.
2. Add onmiss to allow singleton users to register onmiss events as well