### PR TITLE
Memoise - improve key lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.4.0",
+  "version": "1.5.1-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.5.0",
+  "version": "1.5.1-rc.1",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/tests/memoise.js
+++ b/tests/memoise.js
@@ -1,0 +1,52 @@
+const {expect} = require('chai');
+
+const I18n = require('../');
+const translations = require('./translations-stub.json');
+
+describe('memoise (key lookups)', () => {
+    {
+        const i18n = new I18n({translations});
+        const memory = Object.getOwnPropertySymbols(i18n).filter((symbol) => typeof i18n[symbol] === 'object' &&
+            !(i18n[symbol] instanceof Array) &&
+            Object.keys(i18n[symbol]).length === 0)[0];
+        const iterations = 1e5;
+        const results = [false, true].map((memoise) => {
+            const start = Date.now();
+            let i = iterations;
+
+            while (i--) {
+                i18n.t('controller_name.action_name.name.i.am.in.scope');
+                if (!memoise) {
+                    i18n[memory] = {};
+                }
+            }
+
+            return Date.now() - start;
+        });
+        const percentage = (results[0] - results[1]) / results[0] * 100;
+
+        it(`memoisation optimises by more than 10% (result: ${percentage.toFixed(2)}%)`, () => {
+            expect(percentage).to.above(10);
+        });
+    }
+
+    it('add clears the memory', () => {
+        const i18n = new I18n({translations});
+
+        expect(i18n.t('controller_name.action_name.i.am.in.scope')).to.equal('I am in scope');
+        i18n.add({
+            controller_name: {
+                action_name: {
+                    i: {
+                        am: {
+                            in: {
+                                scope: 'I was modified'
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        expect(i18n.t('controller_name.action_name.i.am.in.scope')).to.equal('I was modified');
+    });
+});


### PR DESCRIPTION
Memoisation of `resolve` operation may improve subsequent lookup time in 50%. Older node environments experience a more significant improvements (See CI Job: 6.9.4 has a larger diff than 8.4.0)

This is more significant in server environments, where the same translation keys are being used over and over again by the same instance.

![image](https://user-images.githubusercontent.com/516342/31125621-90eeea76-a851-11e7-81c7-f2bf84f72acf.png)

