### PR TITLE
Memoise - improve instance subsequent key lookups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.4.0",
+  "version": "1.5.1-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.5.1-rc.1",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.5.0",
+  "version": "1.5.1-rc.1",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.5.1-rc.1",
+  "version": "1.5.1",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/tests/memoise.js
+++ b/tests/memoise.js
@@ -2,6 +2,7 @@ const {expect} = require('chai');
 
 const I18n = require('../');
 const translations = require('./translations-stub.json');
+const largeStub = require('./translations-stubber')('abcdefghij');
 
 describe('memoise (key lookups)', () => {
     {
@@ -9,6 +10,8 @@ describe('memoise (key lookups)', () => {
         const memory = Object.getOwnPropertySymbols(i18n).filter((symbol) => typeof i18n[symbol] === 'object' &&
             !(i18n[symbol] instanceof Array) &&
             Object.keys(i18n[symbol]).length === 0)[0];
+        const dummy = 'something-else';
+
         const iterations = 1e5;
         const results = [false, true].map((memoise) => {
             const start = Date.now();
@@ -16,16 +19,44 @@ describe('memoise (key lookups)', () => {
 
             while (i--) {
                 i18n.t('controller_name.action_name.name.i.am.in.scope');
-                if (!memoise) {
-                    i18n[memory] = {};
-                }
+                i18n[memoise ? dummy : memory] = {};
             }
 
             return Date.now() - start;
         });
         const percentage = (results[0] - results[1]) / results[0] * 100;
 
-        it(`memoisation optimises by more than 10% (result: ${percentage.toFixed(2)}%)`, () => {
+        it(`memoisation optimises the runtime (result: ${percentage.toFixed(2)}%)`, () => {
+            expect(percentage).to.above(2);
+        });
+    }
+
+    {
+        const i18n = new I18n({translations: largeStub.translations});
+        const memory = Object.getOwnPropertySymbols(i18n).filter((symbol) => typeof i18n[symbol] === 'object' &&
+            !(i18n[symbol] instanceof Array) &&
+            Object.keys(i18n[symbol]).length === 0)[0];
+        const dummy = 'something-else';
+
+        const iterations = 1e4;
+        const results = [false, true].map((memoise) => {
+            const start = Date.now();
+            let i = iterations;
+
+            while (i--) {
+                largeStub.keys.forEach((key) => {
+                    i18n.t(key);
+                    i18n[memoise ? dummy : memory] = {};
+                });
+            }
+
+            return Date.now() - start;
+        });
+        const percentage = (results[0] - results[1]) / results[0] * 100;
+
+        it(`memoisation on extra large collections optimises by more than 10% (result: ${percentage.toFixed(2)}%)`, function() {
+            this.retries(3);
+
             expect(percentage).to.above(10);
         });
     }

--- a/tests/memoise.js
+++ b/tests/memoise.js
@@ -1,0 +1,52 @@
+const {expect} = require('chai');
+
+const I18n = require('../');
+const translations = require('./translations-stub.json');
+
+describe('memoise (key lookups)', () => {
+    {
+        const i18n = new I18n({translations});
+        const memory = Object.getOwnPropertySymbols(i18n).filter((symbol) => typeof i18n[symbol] === 'object' &&
+            !(i18n[symbol] instanceof Array) &&
+            Object.keys(i18n[symbol]).length === 0)[0];
+        const iterations = 1e5;
+        const results = [false, true].map((memoise) => {
+            const start = Date.now();
+            let i = iterations;
+
+            while (i--) {
+                i18n.t('controller_name.action_name.name.i.am.in.scope');
+                if (!memoise) {
+                    i18n[memory] = {};
+                }
+            }
+
+            return Date.now() - start;
+        });
+        const percentage = (results[0] - results[1]) / results[0] * 100;
+
+        it(`memoisation optimises by more than 10% (result: ${percentage.toFixed(2)}%)`, () => {
+            expect(percentage).to.above(10);
+        });
+    }
+
+    it('add clears the memory', () => {
+        const i18n = new I18n({translations});
+
+        expect(i18n.t('controller_name.action_name.i.am.in.scope')).to.equal('I am in scope');
+        i18n.add({
+            controller_name: {
+                action_name: {
+                    i: {
+                        am: {
+                            in: {
+                                scope: 'I was modified'
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        expect(i18n.t('controller_name.action_name.i.am.in.scope')).to.equal('I was modified');
+    });
+});

--- a/tests/translations-stubber.js
+++ b/tests/translations-stubber.js
@@ -1,0 +1,24 @@
+module.exports = (seed = 'abcdefgh') => {
+    const translations = (function addToObj(seed, collector = {}) {
+        return seed.split('').reduce((collector, item, index, array) => {
+            const notLast = array.length - index - 1;
+
+            if (notLast) {
+                collector[item] = addToObj(array.join('').substring(1), collector[item]);
+            } else {
+                collector[item] = 'z';
+            }
+
+            return collector;
+
+        }, collector);
+    })(seed, {});
+
+    const keys = seed.split('').map((item, index) => {
+        const suffix = seed.substring(index + 1).split('').join('.');
+
+        return `obj.${seed[index]}${(suffix ? `.${suffix}` : '')}`;
+    });
+
+    return {translations, keys};
+};


### PR DESCRIPTION
Memoisation of `resolve` operation may improve subsequent lookup significantly. Older node environments experience a more significant improvements (See CI Job: 6.9.4 has a larger diff than 8.4.0)

This feature is significant in server environments, where the same translation keys are being used over and over again by the same instance.

| Node 6.9.4 |
| ----------- |
| ![image](https://user-images.githubusercontent.com/516342/31162576-f4ebe390-a8e6-11e7-8f02-b1e17d5bac5b.png) |

| Node 8.4.0 |
| ------------ |
| ![image](https://user-images.githubusercontent.com/516342/31162584-00c0ae44-a8e7-11e7-8833-a5d75e797b55.png) |
