### PR TITLE
Change the priority of scope lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class I18n {
         const scopes = [data || {}, this].map(({$scope}) => $scope).filter(Boolean);
 
         // Create key alternatives with prefixes
-        const alternatives = scopes.map(scope => [scope, key].join('.'))
+        const alternatives = scopes.map((scope) => [scope, key].join('.'));
 
         // Find the first match
         let result = this.find(...alternatives, key);

--- a/index.js
+++ b/index.js
@@ -77,8 +77,14 @@ class I18n {
      * @return {String} translated and interpolated
      */
     translate(key, data) {
+
+        // Collect scopes
         const scopes = [data || {}, this].map(({$scope}) => $scope).filter(Boolean);
+
+        // Create key alternatives with prefixes
         const alternatives = scopes.map(scope => [scope, key].join('.'))
+
+        // Find the first match
         let result = this.find(...alternatives, key);
 
         // Handle one,other translation structure

--- a/index.js
+++ b/index.js
@@ -77,15 +77,9 @@ class I18n {
      * @return {String} translated and interpolated
      */
     translate(key, data) {
-        let result = this.find(...[data, this].reduce((alternatives, item) => {
-            const base = get(item, '$scope');
-
-            if (base !== undefined) {
-                alternatives.push([base, key].join('.'));
-            }
-
-            return alternatives;
-        }, [key]));
+        const scopes = [data || {}, this].map(({$scope}) => $scope).filter(Boolean);
+        const alternatives = scopes.map(scope => [scope, key].join('.'))
+        let result = this.find(...alternatives, key);
 
         // Handle one,other translation structure
         result = getOneOther(result, data);

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@
 const get = require('lodash.get');
 const paraphrase = require('paraphrase');
 const assign = require('@recursive/assign');
-const _global = require('./utils/glob');
 const freeze = require('deep-freeze');
+const _global = require('./utils/glob');
 const getOneOther = require('./utils/get-one-other');
 const jsonclone = require('./utils/jsonclone');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "2.0.0-rc",
+  "version": "1.6.0",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "2.0.0",
+  "version": "2.0.0-rc",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.6.0",
+  "version": "1.5.7",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.5.6",
+  "version": "2.0.0",
   "description": "Translation helper",
   "author": "Fiverr dev team",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ const i18n = new I18n({translations});
 | ------ | ---- | ----------- |
 | `translations` | Object | Representation of translation structure **Must be JSON compliant** otherwise will be treated like an empty object |
 | `missing` | Function | Call this function when a key is missing. Function accepts the key as first argument |
-| `$scope` | String | Omittable prefix. see [Scope](#instance-with-a-scope) |
+| `$scope` | String | Omittable prefix. see [Scope](#instance-with-a-scope) **The base is translations key root** |
 
 ```js
 const i18n = new I18n({
@@ -62,29 +62,28 @@ i18n.t('it_will_take_me_days', {count: 'a lot of'}); // It'll take me a lot of d
 
 ### Instance with a scope
 Priority:
-1. Found result w/o scope
-2. Found result with passed in scope (when applicable)
-3. Found result with instance set scope (when applicable)
+1. Found result with passed in scope (when applicable)
+2. Found result with instance set scope (when applicable)
+3. Found result w/o scope
 
 ```js
 // Global scope setup
 const i18n = new I18n({
     translations: {
-        users: { get: { title: '%{username}\'s page' } }
-    },
-    $scope: 'users.get'
-});
-// Use:
-i18n.t('title', {username: 'Arthur'}); // Arthur's page
-
-// Single use scope (passed in with data)
-const i18n = new I18n({
-    translations: {
-        users: { get: { title: '%{username}\'s page' } }
+        key: 'Top',
+        child: {
+            key: 'Child'
+        },
+        something: {
+            key: 'Something'
+        }
     }
 });
-// Use:
-i18n.t('title', {username: 'Arthur', $scope: 'users.get'}); // Arthur's page
+const child = i18n.spawn('child');
+
+i18n.t('key'); // Top
+child.t('key'); // Child
+child.t('key', $scope: 'something'); // Something
 ```
 
 ### Scoped child instance

--- a/tests/child.js
+++ b/tests/child.js
@@ -44,4 +44,17 @@ describe('child instances', () => {
         expect(i18n.t('title')).to.equal('My App');
         expect(child.t('title')).to.equal('My Page');
     });
+
+    it('Child should check its own scope before parent', () => {
+        const i18n = new I18n({translations: {
+            key: 'Top',
+            child: { key: 'Child' },
+            something: { key: 'Something' }
+        }});
+        const child = i18n.spawn('child');
+
+        expect(i18n.t('key', {$scope: 'something'})).to.equal('Something');
+        expect(child.t('key')).to.equal('Child');
+        expect(child.t('key', {$scope: 'something'})).to.equal('Something');
+    });
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,6 +2,7 @@ const {assert, expect} = require('chai');
 
 const I18n = require('../');
 const translations = require('./translations-stub.json');
+
 const $scope = 'controller_name.action_name';
 
 describe('I18n', () => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -117,7 +117,7 @@ describe('I18n', () => {
         })).to.equal('I am in a different scope');
     });
 
-    it('prefers non contextual string to contextual (found in scope)', () => {
+    it('prefers contextual string to non contextual (found in scope)', () => {
         const more = {
             i: {
                 am: {
@@ -129,6 +129,6 @@ describe('I18n', () => {
         };
         i18n.add(more);
 
-        expect(i18n.translate('i.am.in.scope')).to.equal('and now for something completely different');
+        expect(i18n.translate('i.am.in.scope')).to.equal('I am in scope');
     });
 });

--- a/tests/singleton.js
+++ b/tests/singleton.js
@@ -1,5 +1,6 @@
 const {expect} = require('chai');
 const importFresh = require('import-fresh');
+
 const _global = global;
 
 describe('Singleton', () => {


### PR DESCRIPTION
Scoped results are preferred to un-scoped when a scope is supplied

```js
const i18n = new I18n({translations: {
    key: 'Top',
    child: { key: 'Child' },
    something: { key: 'Something' }
}});
const child = i18n.spawn('child');

i18n.t('key'); // Top
i18n.t('key', {$scope: 'something'}); // Something
child.t('key'); // Child
child.t('key', {$scope: 'something'}); // Something (explicit scope is strongest)
```