### PR TITLE
Support a list of keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.5.8",
+  "version": "1.6.0",
   "description": "Translation helper",
   "keywords": [
     "i18n",

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,16 @@ const i18n = new I18n({
 });
 ```
 
+### Translate
+```js
+i18n.t('my.key'); // I'm a sentence
+```
+
+### Find alternatives
+```js
+i18n.t(['my.missing.key', 'my.key']); // I'm a sentence
+```
+
 ### Add more translations after instantiation
 ```js
 i18n.add({yet: {another: {key: 'I\'m here, too!'}}});

--- a/tests/index.js
+++ b/tests/index.js
@@ -57,6 +57,13 @@ describe('I18n', () => {
         expect(i18n.translate('root.user.name')).to.equal('Martin');
     });
 
+    it('i18n uses keys list to find an existing key', () => {
+        expect(i18n.translate([
+            'root_user_name',
+            'root.user.name'
+        ])).to.equal('Martin');
+    });
+
     it('translate function is bound to instance', () => {
         const translate = i18n.translate;
 
@@ -116,6 +123,18 @@ describe('I18n', () => {
         expect(i18n.translate('i.am.in.scope', {
             $scope: 'another_controller_name.action_name'
         })).to.equal('I am in a different scope');
+    });
+
+    it('keys arrays performs lookup in scope', () => {
+        expect(i18n.translate(
+            [
+                'i.am.not.found',
+                'i.am.in.scope'
+            ],
+            {
+                $scope: 'another_controller_name.action_name'
+            }
+        )).to.equal('I am in a different scope');
     });
 
     it('prefers contextual string to non contextual (found in scope)', () => {

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -4,9 +4,11 @@ const I18n = require('../');
 
 describe('missing keys report', () => {
     it('reports missing keys', () => {
+        let reported = false;
         const i18n = new I18n({
             $scope: 'some.scope',
             missing: (key, scope, translations) => {
+                reported = true;
                 expect(scope).to.equal('some.scope');
                 expect(key).to.equal('a.missing.key');
                 expect(translations).to.be.an('object');
@@ -15,6 +17,58 @@ describe('missing keys report', () => {
         });
 
         i18n.translate('a.missing.key');
+        expect(reported).to.be.true;
+    });
+
+    it('reports missing key for undefined', () => {
+        let reported = false;
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            missing: (key, scope, translations) => {
+                reported = true;
+                expect(scope).to.equal('some.scope');
+                expect(key).to.equal('undefined');
+                expect(translations).to.be.an('object');
+                expect(translations).to.be.empty;
+            }
+        });
+
+        i18n.translate();
+        expect(reported).to.be.true;
+    });
+
+    it('reports missing keys for arrays', () => {
+        let reported = false;
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            missing: (key, scope, translations) => {
+                reported = true;
+                expect(scope).to.equal('some.scope');
+                expect(key).to.equal('a.missing.key,another.missing.key');
+                expect(translations).to.be.an('object');
+                expect(translations).to.be.empty;
+            }
+        });
+
+        i18n.translate(['a.missing.key', 'another.missing.key']);
+        expect(reported).to.be.true;
+    });
+
+    it('does not report missing key when one of the keys was found', () => {
+        let reported = false;
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            missing: () => {
+                reported = true;
+            },
+            translations: {
+                fallback: 'falling back'
+            }
+        });
+
+        const translation = i18n.translate(['a.missing.key', 'fallback']);
+        expect(reported).to.be.false;
+        expect(translation).to.equal('falling back');
     });
 
     it('reports missing keys using "onmiss"', () => {


### PR DESCRIPTION
### Existing behaviour (still supported)
```js
i18n.t('my.key'); // I'm a sentence
```

### Added functionality
```js
i18n.t(['my.missing.key', 'my.key']); // I'm a sentence
```