### PR TITLE
Add onempty handler for empty string, null and undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const TRANSLATIONS = typeof Symbol === 'function' ? Symbol() : '_translations';
 const MISSING = typeof Symbol === 'function' ? Symbol() : '_missing';
 const EMPTY = typeof Symbol === 'function' ? Symbol() : '_empty';
 const EMPTY_VALUES = [null, ''];
+const ACCEPTABLE_RETURN_TYPES = ['object', 'number', 'boolean', 'string'];
 
 const interpolate = paraphrase(/\${([^{}]*)}/g, /%{([^{}]*)}/g, /{{([^{}]*)}}/g);
 
@@ -104,21 +105,14 @@ class I18n {
             ) || I18n.getDefault(...keys);
         }
 
-        switch (typeof result) {
-            case 'object':
-            case 'number':
-            case 'boolean':
-                return result;
-            case 'string':
-                if (result) {
-                    return interpolate(result, data);
-                }
-                break;
-            default:
-                return this[MISSING](
-                    `${key}`, this.$scope, this.translations
-                ) || I18n.getDefault(...keys);
-        }
+        const type = typeof result;
+        result = type === 'string' ? interpolate(result, data) : result;
+
+        return ACCEPTABLE_RETURN_TYPES.includes(type)
+            ? result
+            :  this[MISSING](
+                `${key}`, this.$scope, this.translations
+            ) || I18n.getDefault(...keys);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ class I18n {
 
         return ACCEPTABLE_RETURN_TYPES.includes(type)
             ? result
-            :  this[MISSING](
+            : this[MISSING](
                 `${key}`, this.$scope, this.translations
             ) || I18n.getDefault(...keys);
     }

--- a/index.js
+++ b/index.js
@@ -22,13 +22,13 @@ const interpolate = paraphrase(/\${([^{}]*)}/g, /%{([^{}]*)}/g, /{{([^{}]*)}}/g)
 /**
  * @class I18n
  * @classdesc an object capable of translating keys and interpolate using given data object
- * @param {Object<Object>}   options.translations JSON compliant object
- * @param {Object<String>}   [options.$scope]     Root string to be use for looking for translation keys
- * @param {Object<Function>} [options.missing]    Method to call when key is not found
- * @param {Object<Function>} [options.empty]      Method to call when value is empty
+ * @param {Object}   options.translations JSON compliant object
+ * @param {String}   [options.$scope]     Root string to be use for looking for translation keys
+ * @param {Function} [options.missing]    Method to call when key is not found
+ * @param {Function} [options.empty]      Method to call when value is empty
  */
 class I18n {
-    constructor({translations, $scope, missing, empty} = {translations: {}}) {
+    constructor({translations = {}, $scope, missing, empty} = {translations: {}}) {
         this[TRANSLATIONS] = freeze(jsonclone(translations));
         this[MISSING] = () => undefined;
         this[EMPTY] = () => undefined;

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ const interpolate = paraphrase(/\${([^{}]*)}/g, /%{([^{}]*)}/g, /{{([^{}]*)}}/g)
 class I18n {
     constructor({translations, $scope, missing, empty} = {translations: {}}) {
         this[TRANSLATIONS] = freeze(jsonclone(translations));
-        this[MISSING] = [];
-        this[EMPTY] = [];
+        this[MISSING] = () => undefined;
+        this[EMPTY] = () => undefined;
         this.onmiss(missing);
         this.onempty(empty);
         this.$scope = $scope;
@@ -98,9 +98,9 @@ class I18n {
         // Handle one,other translation structure
         result = getOneOther(result, data);
 
-        if (EMPTY_VALUES.includes(result) && typeof this[EMPTY] === 'function') {
+        if (EMPTY_VALUES.includes(result)) {
             return this[EMPTY](
-                `${key}`, `${result}`, this.$scope, this.translations
+                `${key}`, result, this.$scope, this.translations
             ) || I18n.getDefault(...keys);
         }
 
@@ -115,12 +115,9 @@ class I18n {
                 }
                 break;
             default:
-                if (typeof this[MISSING] === 'function') {
-                    return this[MISSING](
-                        `${key}`, this.$scope, this.translations
-                    ) || I18n.getDefault(...keys);
-                }
-                return I18n.getDefault(...keys);
+                return this[MISSING](
+                    `${key}`, this.$scope, this.translations
+                ) || I18n.getDefault(...keys);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Translation helper",
   "keywords": [
     "i18n",

--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,15 @@ const i18n = new I18n({translations});
 | Option | Type | Description |
 | ------ | ---- | ----------- |
 | `translations` | Object | Representation of translation structure **Must be JSON compliant** otherwise will be treated like an empty object |
-| `missing` | Function | Call this function when a key is missing. Function accepts the key as first argument |
+| `missing` | Function | Call this function when a key is missing. Function accepts arguments: key, scope, translations_object |
+| `empty` | Function | Call this function when a value is empty. Function accepts arguments: key, value, scope, translations_object |
 | `$scope` | String | Omittable prefix. see [Scope](#instance-with-a-scope) **The base is translations key root** |
 
 ```js
 const i18n = new I18n({
     translations: {...},
     missing: key => logMissingKeyEvent({key: `missing_translation.${key.replace(/\W/g, '_')}`}),
+    empty: key => logEmptyValueEvent({key: `empty_translation.${key.replace(/\W/g, '_')}`}),
     $scope: 'my_app.en'
 });
 ```
@@ -148,6 +150,7 @@ const i18n = I18n.singleton;
 // Optional:
 i18n.$scope = 'my.scope';
 i18n.onmiss((key, scope) => console.error(`Missing key "${key}" ${scope ? `In scope: "${scope}"`}`));
+i18n.onempty((key, value, scope) => console.warn(`Empty value "${value}" for key "${key}" ${scope ? `In scope: "${scope}"`}`));
 i18n.add({...});
 ```
 Shortcut:

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,26 @@ i18n.t('my.key'); // I'm a sentence
 i18n.t(['my.missing.key', 'my.key']); // I'm a sentence
 ```
 
+### Handle missing
+By default, missing keys or empty values return the last part of the key
+```js
+i18n.t('this.is.a.missing_key'); // missing key
+```
+
+But returning a truthy value from 'missing' and 'empty' callbacks will allow a custom fallback
+```js
+const i18n = new I18n({
+    translations: {...},
+    empty: (key, value, scope) => {
+        if (scope.startsWith('en-US')) {
+            return; // default fallback
+        }
+        return i18n.t(key, { $scope: 'en-US' }); // Try English
+    },
+    $scope: 'en-US'
+});
+```
+
 ### Add more translations after instantiation
 ```js
 i18n.add({yet: {another: {key: 'I\'m here, too!'}}});

--- a/tests/index.js
+++ b/tests/index.js
@@ -100,7 +100,6 @@ describe('I18n', () => {
         expect(i18n.translate('root.is.a.number')).to.be.a('number');
         expect(i18n.translate('root.is.a.boolean')).to.be.a('boolean');
         expect(i18n.translate('root.is.a.object')).to.be.an('object');
-        expect(i18n.translate('root.is.a.null')).to.be.a('null');
     });
 
     it('add translations', () => {

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -42,7 +42,7 @@ describe('missing keys report', () => {
         undefined,
         null
     ].forEach(
-        item => it(`reports empty value for ${item}`, () => {
+        (item) => it(`reports empty value for ${item}`, () => {
             let reported = false;
             const i18n = new I18n({
                 $scope: 'some.scope',

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -41,7 +41,7 @@ describe('missing keys report', () => {
         let reported = false;
         const i18n = new I18n({
             $scope: 'some.scope',
-            missing: (key, scope, translations) => {
+            missing: () => {
                 reported = true;
             }
         });
@@ -52,22 +52,16 @@ describe('missing keys report', () => {
     });
 
     it('uses onmiss return value as fallback', () => {
-        let reported = false;
         const i18n = new I18n({
             $scope: 'some.scope',
-            missing: (key, scope, translations) => {
-                reported = true;
-                return 'Fallback';
-            }
+            missing: () => 'Fallback'
         });
 
         const value = i18n.translate('some.thing.is_missing');
         expect(value).to.equal('Fallback');
-        expect(reported).to.be.true;
     });
 
     it('uses onempty return value as fallback', () => {
-        let reported = false;
         const i18n = new I18n({
             $scope: 'some.scope',
             translations: {
@@ -75,15 +69,11 @@ describe('missing keys report', () => {
                     some_key: ''
                 }
             },
-            empty: (key, scope, translations) => {
-                reported = true;
-                return 'Fallback';
-            }
+            empty: () => 'Fallback'
         });
 
         const value = i18n.translate('base.some_key');
         expect(value).to.equal('Fallback');
-        expect(reported).to.be.true;
     });
 
     [

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -61,6 +61,20 @@ describe('missing keys report', () => {
         expect(value).to.equal('Fallback');
     });
 
+    it('uses last part of the key on empty when no return value was given', () => {
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            translations: {
+                base: {
+                    some_key: ''
+                }
+            }
+        });
+
+        const value = i18n.translate('base.some_key');
+        expect(value).to.equal('some key');
+    });
+
     it('uses onempty return value as fallback', () => {
         const i18n = new I18n({
             $scope: 'some.scope',
@@ -93,7 +107,7 @@ describe('missing keys report', () => {
                     reported = true;
                     expect(scope).to.equal('some.scope');
                     expect(key).to.equal('base.some_key');
-                    expect(value).to.equal(`${item}`);
+                    expect(value).to.equal(item);
                     expect(translations).to.be.an('object');
                 }
             });

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -37,27 +37,33 @@ describe('missing keys report', () => {
         expect(reported).to.be.true;
     });
 
-    it('reports empty value for undefined', () => {
-        let reported = false;
-        const i18n = new I18n({
-            $scope: 'some.scope',
-            translations: {
-                base: {
-                    some_key: ''
+    [
+        '',
+        undefined,
+        null
+    ].forEach(
+        item => it(`reports empty value for ${item}`, () => {
+            let reported = false;
+            const i18n = new I18n({
+                $scope: 'some.scope',
+                translations: {
+                    base: {
+                        some_key: item
+                    }
+                },
+                empty: (key, value, scope, translations) => {
+                    reported = true;
+                    expect(scope).to.equal('some.scope');
+                    expect(key).to.equal('base.some_key');
+                    expect(value).to.equal(`${item}`);
+                    expect(translations).to.be.an('object');
                 }
-            },
-            empty: (key, value, scope, translations) => {
-                reported = true;
-                expect(scope).to.equal('some.scope');
-                expect(key).to.equal('base.some_key');
-                expect(value).to.equal('');
-                expect(translations).to.be.an('object');
-            }
-        });
+            });
 
-        i18n.translate('base.some_key');
-        expect(reported).to.be.true;
-    });
+            i18n.translate('base.some_key');
+            expect(reported).to.be.true;
+        })
+    );
 
     it('reports missing keys for arrays', () => {
         let reported = false;

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -37,9 +37,57 @@ describe('missing keys report', () => {
         expect(reported).to.be.true;
     });
 
+    it('uses last part of the key on missing', () => {
+        let reported = false;
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            missing: (key, scope, translations) => {
+                reported = true;
+            }
+        });
+
+        const value = i18n.translate('some.thing.is_missing');
+        expect(value).to.equal('is missing');
+        expect(reported).to.be.true;
+    });
+
+    it('uses onmiss return value as fallback', () => {
+        let reported = false;
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            missing: (key, scope, translations) => {
+                reported = true;
+                return 'Fallback';
+            }
+        });
+
+        const value = i18n.translate('some.thing.is_missing');
+        expect(value).to.equal('Fallback');
+        expect(reported).to.be.true;
+    });
+
+    it('uses onempty return value as fallback', () => {
+        let reported = false;
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            translations: {
+                base: {
+                    some_key: ''
+                }
+            },
+            empty: (key, scope, translations) => {
+                reported = true;
+                return 'Fallback';
+            }
+        });
+
+        const value = i18n.translate('base.some_key');
+        expect(value).to.equal('Fallback');
+        expect(reported).to.be.true;
+    });
+
     [
         '',
-        undefined,
         null
     ].forEach(
         (item) => it(`reports empty value for ${item}`, () => {
@@ -60,8 +108,9 @@ describe('missing keys report', () => {
                 }
             });
 
-            i18n.translate('base.some_key');
+            const value = i18n.translate('base.some_key');
             expect(reported).to.be.true;
+            expect(value).to.equal('some key');
         })
     );
 

--- a/tests/missing-key.js
+++ b/tests/missing-key.js
@@ -37,6 +37,28 @@ describe('missing keys report', () => {
         expect(reported).to.be.true;
     });
 
+    it('reports empty value for undefined', () => {
+        let reported = false;
+        const i18n = new I18n({
+            $scope: 'some.scope',
+            translations: {
+                base: {
+                    some_key: ''
+                }
+            },
+            empty: (key, value, scope, translations) => {
+                reported = true;
+                expect(scope).to.equal('some.scope');
+                expect(key).to.equal('base.some_key');
+                expect(value).to.equal('');
+                expect(translations).to.be.an('object');
+            }
+        });
+
+        i18n.translate('base.some_key');
+        expect(reported).to.be.true;
+    });
+
     it('reports missing keys for arrays', () => {
         let reported = false;
         const i18n = new I18n({

--- a/tests/translations-stub.json
+++ b/tests/translations-stub.json
@@ -12,8 +12,7 @@
             "a": {
                 "number": 1,
                 "object": {"a": 2},
-                "boolean": false,
-                "null": null
+                "boolean": false
             }
         },
         "interpolated": {


### PR DESCRIPTION
Docs added:
```js
i18n.onempty((key, value, scope) => console.warn(`Empty value "${value}" for key "${key}" ${scope ? `In scope: "${scope}"`}`));
```

Allow custom fallbacks
```js
const i18n = new I18n({
    translations: {...},
    empty: (key, value, scope) => {
        if (scope.startsWith('en-US')) {
            return; // default fallback
        }

		log(`key ${key} has empty value ${value} in scope ${scope}`);
        return i18n.t(key, { $scope: 'en-US' }); // Try English
    },
    $scope: 'en-US'
});
```