### PR TITLE
[FIX] - replace lodash merge with recursive assign 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@
  */
 
 const get = require('lodash.get');
-const merge = require('lodash.merge');
 const paraphrase = require('paraphrase');
+const assign = require('@recursive/assign');
 const freeze = require('deep-freeze');
 const _global = require('./utils/glob');
 const getOneOther = require('./utils/get-one-other');
@@ -71,7 +71,7 @@ class I18n {
      */
     add(...args) {
         args.unshift({}, this.translations);
-        this[TRANSLATIONS] = freeze(merge(...args));
+        this[TRANSLATIONS] = freeze(assign(...args));
 
         return this;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Translation helper",
   "keywords": [
     "i18n",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.8.3-rc",
+  "version": "1.8.3",
   "description": "Translation helper",
   "keywords": [
     "i18n",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "lint": "eslint -c .eslintrc '**/*.js' '*.js'"
   },
   "dependencies": {
+    "@recursive/assign": "^1.2.5",
     "deep-freeze": "0.0.1",
     "lodash.get": "^4.4.2",
-    "lodash.merge": "^4.6.2",
     "paraphrase": "^1.7.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint -c .eslintrc '**/*.js' '*.js'"
   },
   "dependencies": {
-    "@recursive/assign": "^2.0.0",
+    "@recursive/assign": "^2.0.1",
     "deep-freeze": "0.0.1",
     "lodash.get": "^4.4.2",
     "paraphrase": "^1.7.3"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint -c .eslintrc '**/*.js' '*.js'"
   },
   "dependencies": {
-    "@recursive/assign": "^2.0.1",
+    "@recursive/assign": "^2.0.2",
     "deep-freeze": "0.0.1",
     "lodash.get": "^4.4.2",
     "paraphrase": "^1.7.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.8.3",
+  "version": "1.8.3-rc",
   "description": "Translation helper",
   "keywords": [
     "i18n",
@@ -23,7 +23,7 @@
     "lint": "eslint -c .eslintrc '**/*.js' '*.js'"
   },
   "dependencies": {
-    "@recursive/assign": "^1.2.5",
+    "@recursive/assign": "^2.0.0",
     "deep-freeze": "0.0.1",
     "lodash.get": "^4.4.2",
     "paraphrase": "^1.7.3"

--- a/tests/index.js
+++ b/tests/index.js
@@ -102,12 +102,20 @@ describe('I18n', () => {
         expect(i18n.translate('root.is.a.object')).to.be.an('object');
     });
 
-    it('add translations', () => {
+    it('add translations - value type: object', () => {
         expect(i18n.translate('just.another.missing_key')).to.equal('missing key');
         i18n.add({just: {another: {missing_key: 'different value'}}});
         expect(i18n.translate('just.another.missing_key')).to.equal('different value');
         i18n.add({yet: {another: {key: 'I exist, too'}}});
         expect(i18n.translate('yet.another.key')).to.equal('I exist, too');
+    });
+
+    it('add translations - value type: array', () => {
+        expect(i18n.translate('just.another.missing_key_for_array')).to.equal('missing key for array');
+        i18n.add({just: {another: {missing_key_for_array: ['a', 'b']}}});
+        expect(i18n.translate('just.another.missing_key_for_array')).to.deep.equal(['a', 'b']);
+        i18n.add({just: {another: {missing_key_for_array: ['a', 'b', 'c']}}});
+        expect(i18n.translate('just.another.missing_key_for_array')).to.deep.equal(['a', 'b', 'c']);
     });
 
     it('finds translations in scope', () => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -102,20 +102,12 @@ describe('I18n', () => {
         expect(i18n.translate('root.is.a.object')).to.be.an('object');
     });
 
-    it('add translations - value type: object', () => {
+    it('add translations', () => {
         expect(i18n.translate('just.another.missing_key')).to.equal('missing key');
         i18n.add({just: {another: {missing_key: 'different value'}}});
         expect(i18n.translate('just.another.missing_key')).to.equal('different value');
         i18n.add({yet: {another: {key: 'I exist, too'}}});
         expect(i18n.translate('yet.another.key')).to.equal('I exist, too');
-    });
-
-    it('add translations - value type: array', () => {
-        expect(i18n.translate('just.another.missing_key_for_array')).to.equal('missing key for array');
-        i18n.add({just: {another: {missing_key_for_array: ['a', 'b']}}});
-        expect(i18n.translate('just.another.missing_key_for_array')).to.deep.equal(['a', 'b']);
-        i18n.add({just: {another: {missing_key_for_array: ['a', 'b', 'c']}}});
-        expect(i18n.translate('just.another.missing_key_for_array')).to.deep.equal(['a', 'b', 'c']);
     });
 
     it('finds translations in scope', () => {


### PR DESCRIPTION
This reverts https://github.com/fiverr/i18n.js/commit/39f208addfd8151561538deaad90e25168ca9806 and replaces usage of lodash merge with version 2 of recursive assign.

lodash has performance issues:
https://github.com/lodash/lodash/issues/1865
https://github.com/reduxjs/redux/issues/1262#issuecomment-173931750

Since this change deploys to gig page perseus raise the cpu dramatically which result in massive amount of timeouts. (In the image below you can see the results of 2 faulty deploys):
<img width="688" alt="Screen Shot 2020-04-02 at 15 28 41" src="https://user-images.githubusercontent.com/37267423/78249266-becb6900-74f6-11ea-9a38-43677c669508.png">

I isolated all the dependencies that were added in recent days in gig page and tested on dev the following PR which explicitly add version 1.8.2 of i18n to gig page. When deploying in dev I've noticed an increment in cpu (the orange line) which went down only after deploying a different tag (the yellow tag):
<img width="696" alt="Screen Shot 2020-04-02 at 13 24 04" src="https://user-images.githubusercontent.com/37267423/78249111-78760a00-74f6-11ea-8389-ac7fc13fefb6.png">
