### PR TITLE
[FEAT] inject template

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,7 @@ class I18n {
 
         const type = typeof result;
         result = type === 'string' ? interpolate(result, data) : result;
-
-        result = injectTemplates(result, data);
+        result = type === 'string' ? injectTemplates(result, data) : result;
 
         return ACCEPTABLE_RETURN_TYPES.includes(type)
             ? result

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const freeze = require('deep-freeze');
 const _global = require('./utils/glob');
 const getOneOther = require('./utils/get-one-other');
 const jsonclone = require('./utils/jsonclone');
+const injectTemplates = require('./inject-templates');
 
 const TRANSLATIONS = typeof Symbol === 'function' ? Symbol() : '_translations';
 const MISSING = typeof Symbol === 'function' ? Symbol() : '_missing';
@@ -107,6 +108,8 @@ class I18n {
 
         const type = typeof result;
         result = type === 'string' ? interpolate(result, data) : result;
+
+        result = injectTemplates(result, data);
 
         return ACCEPTABLE_RETURN_TYPES.includes(type)
             ? result

--- a/inject-templates/config.js
+++ b/inject-templates/config.js
@@ -1,0 +1,7 @@
+const templateStartSymbol = '_';
+const templateEndSymbol = '_';
+
+module.exports = {
+    templateStartSymbol,
+    templateEndSymbol
+};

--- a/inject-templates/index.js
+++ b/inject-templates/index.js
@@ -16,15 +16,10 @@ function injectTemplates(translation, data) {
     let i = 0;
 
     while (match && match.length) {
-        const search = result.search(templateEndSymbol);
-
         const currentMatch = match[0];
         const currentTemplate = templates[i];
 
-        const prefix = result.substring(0, search);
-        const matchContent = currentMatch.substring(templateStartSymbol.length, currentMatch.length - templateStartSymbol.length - templateEndSymbol.length + 1);
-        const suffix = result.substring(prefix.length + currentMatch.length);
-
+        const [prefix, matchContent, suffix] = deconstruct(result, currentMatch);
         result = `${prefix}${currentTemplate(matchContent)}${suffix}`;
 
         match = result.match(templateRegex);
@@ -32,6 +27,33 @@ function injectTemplates(translation, data) {
     }
 
     return result;
+}
+
+function deconstruct(result, match) {
+    const prefix = extractPrefix(result);
+    const matchContent = extractMatchContent(match);
+    const suffix = extractSuffix(result, prefix, match);
+
+    return [prefix, matchContent, suffix];
+}
+
+function extractPrefix(result) {
+    const startIndex = 0;
+    const length = result.search(templateRegex);
+
+    return result.substring(startIndex, length);
+}
+
+function extractMatchContent(match) {
+    const startIndex = templateStartSymbol.length;
+    const length = match.length - templateStartSymbol.length - templateEndSymbol.length + 1;
+
+    return match.substring(startIndex, length);
+}
+
+function extractSuffix(result, prefix, match) {
+    const startIndex = prefix.length + match.length;
+    return result.substring(startIndex);
 }
 
 module.exports = injectTemplates;

--- a/inject-templates/index.js
+++ b/inject-templates/index.js
@@ -4,7 +4,7 @@ const { templateStartSymbol, templateEndSymbol } = require('./config');
 const templateRegex = new RegExp(`\\${templateStartSymbol}([^${templateStartSymbol}${templateEndSymbol}]+)${templateEndSymbol}`, 'g');
 
 function injectTemplates(translation, data) {
-    if (!has(data, '$templates')) {
+    if (!data || !has(data, '$templates')) {
         return translation;
     }
 

--- a/inject-templates/index.js
+++ b/inject-templates/index.js
@@ -1,0 +1,37 @@
+const has = require('../utils/has');
+const { templateStartSymbol, templateEndSymbol } = require('./config');
+
+const templateRegex = new RegExp(`\\${templateStartSymbol}([^${templateStartSymbol}${templateEndSymbol}]+)${templateEndSymbol}`, 'g');
+
+function injectTemplates(translation, data) {
+    if (!has(data, '$templates')) {
+        return translation;
+    }
+
+    const templates = data.$templates;
+
+    let result = translation;
+
+    let match = result.match(templateRegex);
+    let i = 0;
+
+    while (match && match.length) {
+        const search = result.search(templateEndSymbol);
+
+        const currentMatch = match[0];
+        const currentTemplate = templates[i];
+
+        const prefix = result.substring(0, search);
+        const matchContent = currentMatch.substring(templateStartSymbol.length, currentMatch.length - templateStartSymbol.length - templateEndSymbol.length + 1);
+        const suffix = result.substring(prefix.length + currentMatch.length);
+
+        result = `${prefix}${currentTemplate(matchContent)}${suffix}`;
+
+        match = result.match(templateRegex);
+        i++;
+    }
+
+    return result;
+}
+
+module.exports = injectTemplates;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "description": "Translation helper",
   "keywords": [
     "i18n",

--- a/tests/inject-templates.js
+++ b/tests/inject-templates.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+const injectTemplates = require('../inject-templates');
+const { templateStartSymbol, templateEndSymbol } = require('../inject-templates/config');
+
+describe('inject-templates', () => {
+    describe('when data.$templates is undefined', () => {
+        const translation = 'some translation';
+        const data = { '$not-templates': 123 };
+        const expectedResult = translation;
+
+        it('should return `translation`', () => {
+            expect(injectTemplates(translation, data)).to.equal(expectedResult);
+        });
+    });
+
+    describe('when data.$templates is defined', () => {
+        describe('when translation contains 1 template', () => {
+            const translation = `Hey, Mark! Please ${templateStartSymbol}click here${templateEndSymbol} to view our latest blah blah`;
+            const data = {
+                '$templates': [
+                    (text) => `<a href="#">${text}</a>`
+                ]
+            };
+            const expectedResult = 'Hey, Mark! Please <a href="#">click here</a> to view our latest blah blah';
+
+            it('should inject the templates into the translation string', () => {
+                expect(injectTemplates(translation, data)).to.equal(expectedResult);
+            });
+        });
+
+        describe('when translation contains 2 templates', () => {
+            const translation = `Hey, ${templateStartSymbol}Mark${templateEndSymbol}! Please ${templateStartSymbol}click here${templateEndSymbol} to view our latest blah blah`;
+            const data = {
+                '$templates': [
+                    (text) => `<strong>${text}</strong>`,
+                    (text) => `<a href="#">${text}</a>`
+                ]
+            };
+            const expectedResult = 'Hey, <strong>Mark</strong>! Please <a href="#">click here</a> to view our latest blah blah';
+
+            it('should inject the templates into the translation string', () => {
+                expect(injectTemplates(translation, data)).to.equal(expectedResult);
+            });
+        });
+    });
+});

--- a/utils/get-one-other.js
+++ b/utils/get-one-other.js
@@ -1,3 +1,5 @@
+const has = require('./has');
+
 /**
  * get "one" or "other" from translation key item
  * @param  {Any} result
@@ -24,11 +26,3 @@ const isOneOther = (result, data) =>
     has(result, 'one') &&
     has(result, 'other') &&
     has(data, 'count');
-
-/**
- * Use Object prototype's hasOwnProperty directly
- * @param  {Object} target
- * @param  {String} property
- * @return {Boolean}
- */
-const has = (target, property) => Object.prototype.hasOwnProperty.call(target, property);

--- a/utils/has.js
+++ b/utils/has.js
@@ -1,0 +1,10 @@
+
+/**
+ * Use Object prototype's hasOwnProperty directly
+ * @param  {Object} target
+ * @param  {String} property
+ * @return {Boolean}
+ */
+const has = (target, property) => Object.prototype.hasOwnProperty.call(target, property);
+
+module.exports = has;


### PR DESCRIPTION
### Why?
In theory, we would want our translations to be as clean as possible. Since in some cases developers need to construct complex strings which contain pieces of HTML and JS (see example below), it can lead to inserting code into the text we wish to translate. What if the good folks at our translations service won't know how to correctly translate the text when there's code in it? Therefore, this is an anti-pattern.

**Example (anti-pattern):**

```
"some-key": "Welcome! Please <a href='#' onClick='doSomething()'>click here</a> for more info."
```

### Solution
Accept the `$templates` property inside the data param of the `.t()` function.
A template can be declared by wrapping it with underscores (`_`).

**Example:**

The translation value should now be:
```
Welcome! Please _click here_ for more info.
```
And then calling `i18n.t()` with a template:
```
i18n.t("some-key", {
    $templates: [
        (text) => `<a href="#" onClick="doSomething()">${text}</a>`
]})
```

Why not wrap a template with `${}` or something?
Because our translator-folks know **not** to translate the contents of such strings.