### PR TITLE
Change `has` to return false for empty values

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,8 @@ class I18n {
             []
         );
 
-        return typeof this.find(...alternatives) !== 'undefined';
+        const result = this.find(...alternatives);
+        return typeof result !== 'undefined' && !EMPTY_VALUES.includes(result);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Translation helper",
   "keywords": [
     "i18n",

--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ require('@fiverr/i18n/singleton');
 ```
 
 ### Helper functions
-Check if a key is available (including empty strings)
+Check if a key is available
 #### has
 ```js
 i18n.has('key');

--- a/tests/index.js
+++ b/tests/index.js
@@ -168,7 +168,6 @@ describe('I18n', () => {
 
         [
             [ 'lookup.key' ],
-            [ 'lookup.biscuit' ],
             [ ['lookup.pie', 'lookup.key'] ],
             [ 'key', { $scope: 'lookup' } ],
             [ [ 'pie', 'key' ], { $scope: 'lookup' } ]
@@ -189,7 +188,7 @@ describe('I18n', () => {
         const child = i18n.spawn('lookup');
 
         expect(child.has('key'), 'child.key').to.be.true;
-        expect(child.has('biscuit'), 'child.biscuit').to.be.true;
+        expect(child.has('biscuit'), 'child.biscuit').to.be.false;
         expect(child.has('pie'), 'child.pie').to.be.false;
     });
 });


### PR DESCRIPTION
- Currently when calling `has` with a key that has an empty value (Empty string or null) the return value will be true. This creates a diff between English locale and all others as our policy for non English locales is to have an empty string to begin with.
- This PR changes the above behaviour so that empty values will be taken into consideration as well when using `has`.