### PR TITLE
Update CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,10 @@
 defaults: &defaults
   working_directory: ~/app
   docker:
-    - image: circleci/node:12
+    - image: cimg/node:18.17
+      auth:
+        username: $DOCKER_USER
+        password: $DOCKER_PASS
 
 commands:
   runtests:
@@ -23,65 +26,41 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: Install dependencies
-          command: npm i
+      - run: npm i
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
-  testnode12:
-    <<: *defaults
-    docker:
-      - image: circleci/node:12
-    steps:
-      - runtests
-  testnode14:
-    <<: *defaults
-    docker:
-      - image: circleci/node:14
-    steps:
-      - runtests
-  testnode16:
-    <<: *defaults
-    docker:
-      - image: circleci/node:16
-    steps:
-      - runtests
-  testnode18:
-    <<: *defaults
-    docker:
-      - image: cimg/node:18.17.1
-    steps:
-      - runtests
-  testnode20:
-    <<: *defaults
-    docker:
-      - image: cimg/node:20.5.1
-    steps:
-      - runtests
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./node_modules
   test:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: Run tests
-          command: npm t
-  lint:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: Check syntax
-          command: npm run lint -- --plugin log
-  publish:
+      - attach_workspace:
+          at: .
+      - run: npm t
+      - run: npm run lint -- --plugin log
+  compatibility:
+    parameters:
+      image:
+        description: "node version"
+        default: "lts"
+        type: string
     <<: *defaults
     docker:
-      - image: circleci/node:12
+      - image: "cimg/node:<<parameters.image>>"
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - checkout
+      - run: npm i
+      - run: npm t
+  publish:
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
@@ -108,28 +87,26 @@ workflows:
   version: 2.1
   ci-cd:
     jobs:
-      - install
+      - install:
+          context: org-global
+      - compatibility:
+          context: org-global
+          matrix:
+            parameters:
+              image:
+                - "14.21"
+                - "16.20"
+                # - "18.17" // default image
+                - "20.5"
       - test:
+          context: org-global
           requires:
             - install
-      - lint:
-          requires:
-            - install
-      - testnode12
-      - testnode14
-      - testnode16
-      - testnode18
-      - testnode20
       - publish:
           context: org-global
           requires:
             - test
-            - lint
-            - testnode12
-            - testnode14
-            - testnode16
-            - testnode18
-            - testnode20
+            - compatibility
       - glossary:
           context: org-global
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,15 +23,14 @@ jobs:
           root: .
           paths:
             - ./node_modules
-  test:
+  lint:
     <<: *defaults
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm t
       - run: npm run lint -- --plugin log
-  compatibility:
+  test:
     parameters:
       image:
         description: "node version"
@@ -77,16 +76,16 @@ workflows:
     jobs:
       - install:
           context: org-global
-      - compatibility:
+      - test:
           context: org-global
           matrix:
             parameters:
               image:
                 - "14.21"
                 - "16.20"
-                # - "18.17" // default image
+                - "18.17"
                 - "20.5"
-      - test:
+      - lint:
           context: org-global
           requires:
             - install
@@ -94,7 +93,7 @@ workflows:
           context: org-global
           requires:
             - test
-            - compatibility
+            - lint
       - glossary:
           context: org-global
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,6 @@ defaults: &defaults
         username: $DOCKER_USER
         password: $DOCKER_PASS
 
-commands:
-  runtests:
-    description: "Checkout, install dependencies, and run tests"
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm i
-      - run:
-          name: Run tests
-          command: npm t
-
 version: 2.1
 jobs:
   install:


### PR DESCRIPTION
1. Use a matrix to run the same step with multiple images
1. Use the new [cimg](https://circleci.com/developer/images/image/cimg/node) images instead of the deprecated "circleci" (EOL 2 years ago with node 17)
1. Improved use of cache layer and workspace persistence

![](https://github.com/fiverr/i18n.js/assets/516342/8e517dca-3956-499a-90f3-ac764bcf033b)

