### PR TITLE
[Deps] Upgrade Paraphrase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,6 @@ defaults: &defaults
   docker:
     - image: circleci/node:12
 
-commands:
-  runtests:
-    description: "Checkout, install dependencies, and run tests"
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm i
-      - run:
-          name: Run tests
-          command: npm t
-
 version: 2.1
 jobs:
   install:
@@ -30,24 +18,6 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
-  testnode6:
-    <<: *defaults
-    docker:
-      - image: circleci/node:6.11.5
-    steps:
-      - runtests
-  testnode8:
-    <<: *defaults
-    docker:
-      - image: circleci/node:8
-    steps:
-      - runtests
-  testnode10:
-    <<: *defaults
-    docker:
-      - image: circleci/node:10
-    steps:
-      - runtests
   test:
     <<: *defaults
     steps:
@@ -103,17 +73,11 @@ workflows:
       - lint:
           requires:
             - install
-      - testnode6
-      - testnode8
-      - testnode10
       - publish:
           context: org-global
           requires:
             - test
             - lint
-            - testnode6
-            - testnode8
-            - testnode10
       - glossary:
           context: org-global
           requires:

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  */
 
 const get = require('lodash.get');
-const paraphrase = require('paraphrase');
+const { paraphrase } = require('paraphrase');
 const assign = require('@recursive/assign');
 const freeze = require('deep-freeze');
 const _global = require('./utils/glob');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/i18n",
-  "version": "1.8.4",
+  "version": "1.8.5-rc",
   "description": "Translation helper",
   "keywords": [
     "i18n",
@@ -26,7 +26,7 @@
     "@recursive/assign": "^2.0.2",
     "deep-freeze": "0.0.1",
     "lodash.get": "^4.4.2",
-    "paraphrase": "^1.7.3"
+    "paraphrase": "^3.1.1"
   },
   "devDependencies": {
     "@fiverr/eslint-config-fiverr": "^3.1.3",


### PR DESCRIPTION
**Main changes**
As part of [Upgrading to Storybook@7](https://github.com/fiverr/platform_sphinx/pull/780), it seems parcel bundled which is used throws on `parcelRequire` is not a function ([indrect to](https://github.com/parcel-bundler/parcel/issues/1401#issuecomment-424501260)).

this PR updates it to `3.x.x` which uses `esbuild` instead which is fully compatible.

There shouldn't be any logic changes please correct me if I'm wrong @omrilotan 🙏 

Depends on: https://github.com/fiverr/i18n.js/pull/91